### PR TITLE
Fix #2 making windows users a bit happier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-in-node
 This is an comparison of different methods of calling `Rust` code from `Node` with benchmarks.
-You should have [`node@4.x.x`](https://nodejs.org/download/) and [`rust@1.1.0`](http://www.rust-lang.org/) installed and [`node-gyp`](https://github.com/TooTallNate/node-gyp/) configured.
+You should have [`node@4.x.x`](https://nodejs.org/download/) and [`rust@1.1.0`](http://www.rust-lang.org/)+ installed and [`node-gyp`](https://github.com/TooTallNate/node-gyp/) configured.
 
 ## Methods
 There are few different ways to call rust from node. All of them are besed on `FFI` ([Foreign Function Interface](https://doc.rust-lang.org/book/ffi.html))

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Minimal steps to crete dynamic library with rust
     cargo new embed
     cd embed
     edit src/lib.rs
-    
+
 ```rust
 #[no_mangle]
 pub extern fn fibonacci(n: i32) -> i32 {
@@ -21,7 +21,7 @@ pub extern fn fibonacci(n: i32) -> i32 {
 }
 ```
 
-    edit Cargo.toml 
+    edit Cargo.toml
 add to bottom
 ```toml
 [lib]
@@ -50,7 +50,7 @@ lib.fibonacci(10) // 89
 NOTE: path could be different
 
 ### Call dynamic library via c++ addon
-This is most complicate way because you have to write `c++` a bit. You can read more about native modules [`here`](https://nodejs.org/api/addons.html) 
+This is most complicate way because you have to write `c++` a bit. You can read more about native modules [`here`](https://nodejs.org/api/addons.html)
 
     mkdir cpp-ffi
     cd cpp-ffi
@@ -77,8 +77,8 @@ void init(Handle<Object> exports) {
 
 NODE_MODULE(addon, init)
 ```
-    
-    edit binding.gyp 
+
+    edit binding.gyp
 
 ```
 {
@@ -108,7 +108,7 @@ Then you can build module
     cd rust-in-node
     npm install
     npm run build
-    
+
 ## Benchmark
     node benchmark
 
@@ -121,6 +121,25 @@ nativeCppFFI.fibonacci(10)  x 1,825,865 ops/sec ±1.31% (89 runs sampled)
 ```
 
 As you can see the direct ffi call is to slow to have deal with it, but ffi + `C++` wrapper as fast as a native `C++` module, so `Rust` is good candidate for native modules for `Nodejs`
+
+## Building on windows
+Building on windows might be a challenging task, because `node-gyp` makes everyone
+unhappy on windows.
+
+If everything is configured properly `npm run build` should just work.
+
+However it is likely to be broken. Try these steps if it is:
+
+1. First ensure that you followed all windows installation instruction from README on https://github.com/nodejs/node-gyp
+2. Ensure that you using the same target for both Rust and C++. Rust should be
+compiled with MSVC target and target platform should be the same (ie i686/win32)
+3. Newer versions of [`Cargo`](https://github.com/rust-lang/cargo) produce `.dll.lib`
+files and older versions produce simply `.lib`. After building rust code please ensure
+that win embed lib name in `src\native-cpp-ffi\binding.gyp` match file names in `rust\target\release`.
+4. If you building only rust and native-cpp-ffi then you need to copy all
+libs compiled by cargo into directory of node addon. In this parcitular case:
+copy `rust/target/release/embed*` to `src/native-cpp-ffi/build/Release`
+
 
 ## Plans
 Test `Rust` module with multithreading. It could give even better result.

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,6 +1,16 @@
 var Benchmark = require('benchmark');
 var suite = new Benchmark.Suite;
 var nativeRustFFI = require('./src/native-rust-ffi');
+/**
+ * In case if you need only C++ rust native call
+ * you need to copy all libs compiled by cargo
+ * into directory of node addon.
+ * In this parcitular case:
+ * copy rust/target/release/embed* to src/native-cpp-ffi/build/Release
+ *
+ * In this example it works without copying this files because ffi
+ * has included native-rust libs in the line of code above
+ */
 var nativeCppFFI = require('./src/native-cpp-ffi');
 var nativeCpp = require('./src/native-cpp');
 var vanilla = require('./src/vanilla');

--- a/src/native-cpp-ffi/addon.cc
+++ b/src/native-cpp-ffi/addon.cc
@@ -1,7 +1,7 @@
 #include <node.h>
+#include <addon.h>
 
 using namespace v8;
-extern int32_t fibonacci(int32_t input);
 
 void Method(const FunctionCallbackInfo<Value>& args) {
 	Isolate* isolate = Isolate::GetCurrent();

--- a/src/native-cpp-ffi/addon.h
+++ b/src/native-cpp-ffi/addon.h
@@ -1,0 +1,9 @@
+#ifdef WIN32
+extern "C" {
+#endif
+
+	extern int32_t fibonacci(int32_t input);
+
+#ifdef WIN32
+}
+#endif

--- a/src/native-cpp-ffi/binding.gyp
+++ b/src/native-cpp-ffi/binding.gyp
@@ -2,6 +2,9 @@
 	"targets": [{
 		"target_name": "addon",
 		"sources": ["addon.cc" ],
+        'include_dirs': [
+          '.',
+        ],
 		"conditions": [
 			['OS=="mac"', {
 				"libraries": [
@@ -10,7 +13,7 @@
 			}],
 			['OS=="win"', {
 				"libraries": [
-					"../../../rust/target/release/libembed.dll"
+					"../../../rust/target/release/embed.dll.lib"
 				]
 			}]
 		]

--- a/src/native-rust-ffi.js
+++ b/src/native-rust-ffi.js
@@ -1,5 +1,8 @@
 var ffi = require('ffi');
+var process = require('process')
 
-module.exports = ffi.Library('rust/target/release/libembed', {
+var isWin = /^win/.test(process.platform);
+
+module.exports = ffi.Library('rust/target/release/'+(!isWin?'lib':'')+'embed', {
 	fibonacci: ['int', ['int']]
 });


### PR DESCRIPTION
Referring #2 

Tested on mac. Works nicely.

vanilla.fibonacci(10)       x 1,323,543 ops/sec ±1.32% (92 runs sampled)
nativeRustFFI.fibonacci(10) x 211,350 ops/sec ±1.48% (92 runs sampled)
nativeCpp.fibonacci(10)     x 3,350,211 ops/sec ±1.23% (88 runs sampled)
nativeCppFFI.fibonacci(10)  x 3,159,406 ops/sec ±3.43% (87 runs sampled)

There's no such difference between Cpp and Cpp+Rust on mac as on windows. That's interesting. I presume that the reason why Cpp+Rust works faster pure Cpp (?!) on windows is in VC++ compilator.
