### PR TITLE
Improve cross-platformity: linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ nativeCppFFI.fibonacci(10)  x 1,825,865 ops/sec ±1.31% (89 runs sampled)
 As you can see the direct ffi call is to slow to have deal with it, but ffi + `C++` wrapper as fast as a native `C++` module, so `Rust` is good candidate for native modules for `Nodejs`
 
 ### Windows
-(i5-4200U, win 10)
+(i5-4200U, Win 10)
 ```
 vanilla.fibonacci(10)       x 1,377,844 ops/sec ±0.16% (97 runs sampled)
 nativeRustFFI.fibonacci(10) x 339,064 ops/sec ±0.28% (102 runs sampled)
@@ -132,7 +132,16 @@ nativeCpp.fibonacci(10)     x 2,698,431 ops/sec ±0.22% (100 runs sampled)
 nativeCppFFI.fibonacci(10)  x 4,479,237 ops/sec ±0.32% (98 runs sampled)
 ```
 
-For some reason performance of a Rust lib connected to a C++ NodeJS extension via the C ABI is drastically faster. It is quite possibly that VC++ 2015 compiler is suboptimal.
+### Linux
+(same i5-4200U, Ubuntu 15)
+```
+vanilla.fibonacci(10)       x 2,108,353 ops/sec ±0.49% (98 runs sampled)
+nativeRustFFI.fibonacci(10) x 334,195 ops/sec ±0.42% (93 runs sampled)
+nativeCpp.fibonacci(10)     x 4,646,598 ops/sec ±0.40% (100 runs sampled)
+nativeCppFFI.fibonacci(10)  x 5,235,762 ops/sec ±0.70% (100 runs sampled)
+```
+
+For some reason on Windows performance of a Rust lib connected to a C++ NodeJS extension via the C ABI is drastically faster. It is quite possibly that VC++ 2015 compiler is suboptimal. Rust + C++ is also faster on Ubuntu.
 
 ## Building on windows
 Building on windows might be a challenging task, because `node-gyp` makes everyone

--- a/src/native-cpp-ffi/addon.cc
+++ b/src/native-cpp-ffi/addon.cc
@@ -1,7 +1,10 @@
 #include <node.h>
-#include <addon.h>
 
 using namespace v8;
+
+extern "C" {
+	extern int32_t fibonacci(int32_t input);
+}
 
 void Method(const FunctionCallbackInfo<Value>& args) {
 	Isolate* isolate = Isolate::GetCurrent();

--- a/src/native-cpp-ffi/addon.h
+++ b/src/native-cpp-ffi/addon.h
@@ -1,9 +1,0 @@
-#ifdef WIN32
-extern "C" {
-#endif
-
-	extern int32_t fibonacci(int32_t input);
-
-#ifdef WIN32
-}
-#endif

--- a/src/native-cpp-ffi/binding.gyp
+++ b/src/native-cpp-ffi/binding.gyp
@@ -6,6 +6,11 @@
           '.',
         ],
 		"conditions": [
+			['OS=="linux"', {
+				"libraries": [
+					"<(module_root_dir)/../../rust/target/release/libembed.so"
+				]
+			}],
 			['OS=="mac"', {
 				"libraries": [
 					"../../../rust/target/release/libembed.dylib"


### PR DESCRIPTION
-remove win32 conditions, rust module now always included as via C ABI
-add linux condition into binding.gyp
-add Ubuntu linux performance report
