### PR TITLE
add native addon written in rust&neon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
+index.node
 Cargo.lock
 node_modules
 build

--- a/benchmark.js
+++ b/benchmark.js
@@ -14,9 +14,9 @@ var nativeRustFFI = require('./src/native-rust-ffi');
 var nativeCppFFI = require('./src/native-cpp-ffi');
 var nativeCpp = require('./src/native-cpp');
 var vanilla = require('./src/vanilla');
-
+var nativeRustNeon = require('./src/native-rust-neon');
 suite
-	.add('vanilla.fibonacci(10)      ', function () {
+	.add('vanilla.fibonacci(10)', function () {
 		vanilla.fibonacci(10);
 	})
 	.add('nativeRustFFI.fibonacci(10)', function () {
@@ -28,10 +28,15 @@ suite
 	.add('nativeCppFFI.fibonacci(10) ', function () {
 		nativeCppFFI.fibonacci(10);
 	})
+	.add('nativeRustNeon.fibonacci(10) ', function () {
+		nativeRustNeon.fibonacci(10);
+	})
 	.on('complete', function () {
 		console.log(this[0].toString());
 		console.log(this[1].toString());
 		console.log(this[2].toString());
 		console.log(this[3].toString());
+		console.log(this[4].toString());
 	})
 	.run();
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build-rust": "(cd rust && cargo build --release)",
     "build-cpp": "(cd src/native-cpp && node-gyp configure build)",
     "build-cpp-ffi": "(cd src/native-cpp-ffi && node-gyp configure build)",
-    "build": "npm run build-rust && npm run build-cpp && npm run build-cpp-ffi"
+    "build-rust-neon": "(cd src/native-rust-neon && npm install)",
+    "build": "npm run build-rust && npm run build-cpp && npm run build-cpp-ffi && npm run build-rust-neon"
   },
   "author": "",
   "license": "ISC",

--- a/src/native-rust-neon/.gitignore
+++ b/src/native-rust-neon/.gitignore
@@ -1,0 +1,5 @@
+native/target
+native/index.node
+**/*~
+**/node_modules
+**/.DS_Store

--- a/src/native-rust-neon/lib/index.js
+++ b/src/native-rust-neon/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../native');

--- a/src/native-rust-neon/native/Cargo.toml
+++ b/src/native-rust-neon/native/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rsaddon"
+version = "0.1.0"
+authors = ["piaoger"]
+license = "MIT"
+
+[lib]
+name = "rsaddon"
+crate-type = ["dylib"]
+
+[dependencies]
+neon = "0.1"

--- a/src/native-rust-neon/native/src/lib.rs
+++ b/src/native-rust-neon/native/src/lib.rs
@@ -1,0 +1,22 @@
+#[macro_use]
+extern crate neon;
+
+use neon::vm::{Call, JsResult, Module};
+use neon::js::JsInteger;
+
+fn fibonacci(n: i32) -> i32 {
+    return match n {
+        1 | 2 => 1,
+        n => fibonacci(n - 1) + fibonacci(n - 2)
+    }
+}
+
+fn method(call: Call) -> JsResult<JsInteger> {
+    let scope = call.scope;
+    let x = try!(try!(call.arguments.require(scope, 0)).check::<JsInteger>()).value();
+    Ok(JsInteger::new(scope, fibonacci(x as i32)))
+}
+
+register_module!(m, {
+    m.export("fibonacci", method)
+});

--- a/src/native-rust-neon/package.json
+++ b/src/native-rust-neon/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "embedneon",
+  "version": "0.1.0",
+  "description": "node.js addon written in rust & neon",
+  "main": "lib/index.js",
+  "author": "piaoger",
+  "license": "MIT",
+  "dependencies": {
+    "neon-cli": "^0.1.7"
+  },
+  "scripts": {
+    "install": "neon build"
+  }
+}


### PR DESCRIPTION
I added a new native written in rust&neon. It seems that the performance is a little bit worse than nativeCpp and nativeCppFFI.

Below is test result on my Linux machine:
    vanilla.fibonacci(10) x 1,481,437 ops/sec ±0.93% (100 runs sampled)
    nativeRustFFI.fibonacci(10) x 170,863 ops/sec ±0.46% (96 runs sampled)
    nativeCpp.fibonacci(10)     x 2,500,092 ops/sec ±0.22% (103 runs sampled)
    nativeCppFFI.fibonacci(10)  x 2,451,105 ops/sec ±0.93% (96 runs sampled)
    nativeRustNeon.fibonacci(10)  x 2,405,373 ops/sec ±0.17% (97 runs sampled)

For I have no other machines, I have not updated benchmark in readme.
